### PR TITLE
rdflib 6.3.1, split extras into multiple outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_rdflib--tests-green.svg)](https://anaconda.org/conda-forge/_rdflib-tests) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_rdflib-tests.svg)](https://anaconda.org/conda-forge/_rdflib-tests) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_rdflib-tests.svg)](https://anaconda.org/conda-forge/_rdflib-tests) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_rdflib-tests.svg)](https://anaconda.org/conda-forge/_rdflib-tests) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-rdflib-green.svg)](https://anaconda.org/conda-forge/rdflib) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rdflib.svg)](https://anaconda.org/conda-forge/rdflib) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rdflib.svg)](https://anaconda.org/conda-forge/rdflib) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rdflib.svg)](https://anaconda.org/conda-forge/rdflib) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rdflib--with--all-green.svg)](https://anaconda.org/conda-forge/rdflib-with-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rdflib-with-all.svg)](https://anaconda.org/conda-forge/rdflib-with-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rdflib-with-all.svg)](https://anaconda.org/conda-forge/rdflib-with-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rdflib-with-all.svg)](https://anaconda.org/conda-forge/rdflib-with-all) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rdflib--with--html-green.svg)](https://anaconda.org/conda-forge/rdflib-with-html) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rdflib-with-html.svg)](https://anaconda.org/conda-forge/rdflib-with-html) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rdflib-with-html.svg)](https://anaconda.org/conda-forge/rdflib-with-html) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rdflib-with-html.svg)](https://anaconda.org/conda-forge/rdflib-with-html) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rdflib--with--lxml-green.svg)](https://anaconda.org/conda-forge/rdflib-with-lxml) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rdflib-with-lxml.svg)](https://anaconda.org/conda-forge/rdflib-with-lxml) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rdflib-with-lxml.svg)](https://anaconda.org/conda-forge/rdflib-with-lxml) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rdflib-with-lxml.svg)](https://anaconda.org/conda-forge/rdflib-with-lxml) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-rdflib--with--networkx-green.svg)](https://anaconda.org/conda-forge/rdflib-with-networkx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/rdflib-with-networkx.svg)](https://anaconda.org/conda-forge/rdflib-with-networkx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/rdflib-with-networkx.svg)](https://anaconda.org/conda-forge/rdflib-with-networkx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/rdflib-with-networkx.svg)](https://anaconda.org/conda-forge/rdflib-with-networkx) |
 
 Installing rdflib
 =================
@@ -43,41 +48,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `rdflib` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `_rdflib-tests, rdflib, rdflib-with-all, rdflib-with-html, rdflib-with-lxml, rdflib-with-networkx` can be installed with `conda`:
 
 ```
-conda install rdflib
-```
-
-or with `mamba`:
-
-```
-mamba install rdflib
-```
-
-It is possible to list all of the versions of `rdflib` available on your platform with `conda`:
-
-```
-conda search rdflib --channel conda-forge
+conda install _rdflib-tests rdflib rdflib-with-all rdflib-with-html rdflib-with-lxml rdflib-with-networkx
 ```
 
 or with `mamba`:
 
 ```
-mamba search rdflib --channel conda-forge
+mamba install _rdflib-tests rdflib rdflib-with-all rdflib-with-html rdflib-with-lxml rdflib-with-networkx
+```
+
+It is possible to list all of the versions of `_rdflib-tests` available on your platform with `conda`:
+
+```
+conda search _rdflib-tests --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search _rdflib-tests --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search rdflib --channel conda-forge
+mamba repoquery search _rdflib-tests --channel conda-forge
 
-# List packages depending on `rdflib`:
-mamba repoquery whoneeds rdflib --channel conda-forge
+# List packages depending on `_rdflib-tests`:
+mamba repoquery whoneeds _rdflib-tests --channel conda-forge
 
-# List dependencies of `rdflib`:
-mamba repoquery depends rdflib --channel conda-forge
+# List dependencies of `_rdflib-tests`:
+mamba repoquery depends _rdflib-tests --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -167,19 +167,19 @@ outputs:
         - pyproject.toml
       requires:
         - pip
-        - mypy
         - pytest
         - pytest-cov
         - pytest-subtests
+        # - mypy
       imports:
         - rdflib
       commands:
         - pip check
+        # definednamespace_creator: some test fixtures are missing
+        - pytest test -vv -k "not (definednamespace_creator or test_prepare_query)" --cov=rdflib --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=84
         # TODO: restore
         #   Found 4 errors in 3 files (checked 118 source files)
         # - mypy -p rdflib
-        # some test assets are missing
-        - pytest test -vv -k "not definednamespace_creator" --cov=rdflib --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=84
 
 about:
   home: https://github.com/RDFLib/rdflib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,72 +1,196 @@
-{% set version = "6.3.0" %}
+{% set version = "6.3.1" %}
 {% set test_skips = "not (dawg_data_sparql or definednamespace_creator or prepare_query)" %}
-{% set cov_fail_under = 84 %}
 
 package:
-  name: rdflib
+  name: rdflib-split
   version: {{ version }}
 
 source:
-  - folder: dist
-    url: https://pypi.io/packages/source/r/rdflib/rdflib-{{ version }}.tar.gz
-    sha256: 6ea39896a4dbe10f933acf33aaab61d52f390d32e8618add4550d52e6a0d4428
-  - folder: src
-    url: https://github.com/RDFLib/rdflib/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 2a7e0e94463eb0c779f4c2a23800223094a76d9cc42a6d723732364df5e0f92e
+  url: https://pypi.io/packages/source/r/rdflib/rdflib-{{ version }}.tar.gz
+  sha256: ced41883cdd387a53e73bf54d5db8b076e9675b59d8a601166220aa1e60970b6
 
 build:
   number: 0
-  script: cd dist && {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
-  entry_points:
-    - csv2rdf = rdflib.tools.csv2rdf:main
-    - rdf2dot = rdflib.tools.rdf2dot:main
-    - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
-    - rdfpipe = rdflib.tools.rdfpipe:main
-    - rdfs2dot = rdflib.tools.rdfs2dot:main
 
 requirements:
   host:
     - python >=3.7
-    - poetry-core >=1.4.0
-    - pip
   run:
-    - html5lib  # from extras
-    - importlib-metadata
-    - isodate >=0.6.0,<0.7.0
-    - pyparsing >=2.1.0,<4
     - python >=3.7
 
-test:
-  source_files:
-    - src/test
-    - src/pyproject.toml
-  requires:
-    - pip
-    # berkeleydb -> bsddb3
-    # html5lib included in run
-    - bsddb3
-    - networkx
-    - pytest
-    - pytest-cov
-    - pytest-subtests
-    - tabulate  # undeclared, might be removed in >=6.1.2
-  imports:
-    - rdflib
-  commands:
-    - pip check
-    # some missing file not in repo
-    - cd src && pytest test -vv --cov rdflib --cov-report term-missing:skip-covered --no-cov-on-fail -k "{{ test_skips }}" --cov-fail-under {{ cov_fail_under }}
+outputs:
+  - name: rdflib
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+      entry_points:
+        - csv2rdf = rdflib.tools.csv2rdf:main
+        - rdf2dot = rdflib.tools.rdf2dot:main
+        - rdfgraphisomorphism = rdflib.tools.graphisomorphism:main
+        - rdfpipe = rdflib.tools.rdfpipe:main
+        - rdfs2dot = rdflib.tools.rdfs2dot:main
+    requirements:
+      host:
+        - pip
+        - poetry-core >=1.4.0
+        - python >=3.7
+      run:
+        - importlib-metadata
+        - isodate >=0.6.0,<0.7.0
+        - pyparsing >=2.1.0,<4
+        - python >=3.7
+    test:
+      requires:
+        - pip
+      imports:
+        - rdflib
+      commands:
+        - pip check
+        # --help doesn't return 0, just check if they are on $PATH/%PATH%
+        - which csv2rdf              || where csv2rdf              || exit 1
+        - which rdf2dot              || where rdf2dot              || exit 1
+        - which rdfgraphisomorphism  || where rdfgraphisomorphism  || exit 1
+        - which rdfpipe              || where rdfpipe              || exit 1
+        - which rdfs2dot             || where rdfs2dot             || exit 1
+
+  # TODO: apparently had a name change, never updated, and is unlikely to build on windows
+  # - name: rdflib-with-berkeleydb
+  #   build:
+  #     noarch: python
+  #   requirements:
+  #     host:
+  #       - python >=3.7
+  #     run:
+  #       - {{ pin_subpackage("rdflib", max_pin="x.x.x") }}
+  #       - bsddb3
+  #       - python >=3.7
+  #   test:
+  #     requires:
+  #       - pip
+  #     imports:
+  #       - rdflib
+  #     commands:
+  #       - pip check
+  #       - python -c "from rdflib.plugins.stores import berkeleydb; assert berkeleydb.has_bsddb"
+
+  - name: rdflib-with-networkx
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage("rdflib", max_pin="x.x.x") }}
+        - networkx
+        - python >=3.7
+    test:
+      requires:
+        - pip
+      imports:
+        - rdflib
+      commands:
+        - pip check
+        - python -c "from rdflib.extras.external_graph_libs import rdflib_to_networkx_graph; import rdflib; assert rdflib_to_networkx_graph(rdflib.Graph()) is not None"
+
+  - name: rdflib-with-html
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage("rdflib", max_pin="x.x.x") }}
+        - html5lib
+        - python >=3.7
+    test:
+      requires:
+        - pip
+      imports:
+        - rdflib
+      commands:
+        - pip check
+        - python -c "from rdflib.term import _parseHTML; _parseHTML('<html></html>')"
+
+  - name: rdflib-with-lxml
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage("rdflib", max_pin="x.x.x") }}
+        - python >=3.7
+        - lxml
+    test:
+      requires:
+        - pip
+      imports:
+        - rdflib
+      commands:
+        - pip check
+        - python -c "from rdflib.plugins.sparql.results import xmlresults; assert xmlresults.lxml_etree"
+
+  - name: rdflib-with-all
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        # - {{ pin_subpackage("rdflib-with-berkeleydb", max_pin="x.x.x") }}
+        - {{ pin_subpackage("rdflib-with-html", max_pin="x.x.x") }}
+        - {{ pin_subpackage("rdflib-with-lxml", max_pin="x.x.x") }}
+        - {{ pin_subpackage("rdflib-with-networkx", max_pin="x.x.x") }}
+        - {{ pin_subpackage("rdflib", max_pin="x.x.x") }}
+        - python >=3.7
+    test:
+      requires:
+        - pip
+      imports:
+        - rdflib
+      commands:
+        - pip check
+
+  - name: _rdflib-tests
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage("rdflib-with-all", max_pin="x.x.x") }}
+        - python >=3.7
+    test:
+      source_files:
+        - test
+        - pyproject.toml
+      requires:
+        - pip
+        - mypy
+        - pytest
+        - pytest-cov
+        - pytest-subtests
+      imports:
+        - rdflib
+      commands:
+        - pip check
+        # TODO: restore
+        #   Found 4 errors in 3 files (checked 118 source files)
+        # - mypy -p rdflib
+        # some test assets are missing
+        - pytest test -vv -k "not definednamespace_creator" --cov=rdflib --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=84
 
 about:
   home: https://github.com/RDFLib/rdflib
   license: BSD-3-Clause
-  license_file: dist/LICENSE
+  license_file: LICENSE
   summary: RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information.
   dev_url: https://github.com/RDFLib/rdflib
   doc_url: https://rdflib.readthedocs.io
 
 extra:
+  feedstock-name: rdflib
   recipe-maintainers:
     - satra
     - nicholascar


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

References:
- alternative to #26

Changes:
- [x] restore use of tests from `sdist`
- [x] remove deprecated `html5lib` from `rdflib` dependency 
- [x] split out `html5lib` and other extras into multiple outputs, named after the upstreams
  - >  can't do `berkeleydb` [yet](https://github.com/conda-forge/staged-recipes/issues/22320)
- [x] add `rdflib-with-all` with all deps
- [x] add `_rdflib-tests` with the tests assets
  - the tests (and data) are ~80x the size of the actual code on disk